### PR TITLE
Add --download-archive option

### DIFF
--- a/cda_dl-docker.sh
+++ b/cda_dl-docker.sh
@@ -1,5 +1,5 @@
 file=$(mktemp temp.XXXXXXXXX)
 lynx -dump -listonly --nonumbers $1 | grep video/ | sed '$!N; /^\(.*\)\n\1$/!P; D' | sort | uniq >> $file
-yt-dlp -ciw -a $file -o "Pobrane/%(title)s.%(ext)s" --external-downloader aria2c --external-downloader-args '-c -j 10 -x 3 -s 3 -k 1M'
+yt-dlp -ciw -a $file -o "Pobrane/%(title)s.%(ext)s" --external-downloader aria2c --external-downloader-args '-c -j 10 -x 3 -s 3 -k 1M' --download-archive archive.txt
 rm -r lista.txt
 rm -r $file

--- a/cda_dl.sh
+++ b/cda_dl.sh
@@ -1,5 +1,5 @@
 file=$(mktemp temp.XXXXXXXXX)
 lynx -dump -listonly --nonumbers $1 | grep video/ | sed '$!N; /^\(.*\)\n\1$/!P; D' | sort | uniq >> $file
-yt-dlp -ciw -a $file -o "Pobrane/%(title)s.%(ext)s" --external-downloader aria2c --external-downloader-args '-c -j 10 -x 3 -s 3 -k 1M'
+yt-dlp -ciw -a $file -o "Pobrane/%(title)s.%(ext)s" --external-downloader aria2c --external-downloader-args '-c -j 10 -x 3 -s 3 -k 1M' --download-archive archive.txt
 rm -r lista.txt
 rm -r $file


### PR DESCRIPTION
Fix: #58

## Summary by Sourcery

Enhancements:
- Configure yt-dlp in both shell scripts to use a shared download archive file for tracking already downloaded videos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced download performance using aria2c external downloader with configurable concurrency settings
  * Added download archive tracking to prevent re-downloading of previously processed content
  * Improved temporary file cleanup and resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->