### PR TITLE
Remove unnecessary dependencies and clarify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,21 @@ Program/Skrypt do pobierania całego folderu z cda.pl
 Wymagania
 
  - lynx<br>
- - nodejs
- - npm
  - aria2c
  
-  `sudo apt-get install lynx nodejs npm aria2`
+  `sudo apt-get install lynx aria2`
   <br>
   `git clone https://github.com/Bartixxx32/CDA.PL-Folder-Downloader`
   <br>
   `cd CDA.PL-Folder-Downloader`
   <br>
-  `npm install`
 ## Jak używać
 ***Wersja Bash***:<br>
-`npm install`<br>
 `./cda_dl.sh "link"`
 <br>
 <br>Np: `./cda_dl.sh https://www.cda.pl/uzytkownik/folder/12345678` 
+<br>Jeżeli folder posiada kilka stron, skrypt należy uruchomić dla każdej strony:
+<br>Np: `./cda_dl.sh https://www.cda.pl/uzytkownik/folder/12345678/2`
 <br>
 <br>***Wersja Docker***
  


### PR DESCRIPTION
If I'm not mistaken, nodejs is no longer needed by the user? There are still some mentions of it in .gitpod.yml and .github/dependabot.yml but I don't use them and I didn't want to break something.

## Summary by Sourcery

Update usage documentation to remove obsolete Node.js/npm requirements and clarify handling of multi-page folders in the Bash script.

Documentation:
- Remove Node.js and npm from the listed dependencies and installation instructions in the README.
- Document how to use the Bash script with folders that span multiple pages, including example commands.